### PR TITLE
Support 90-degree threads

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,6 +79,7 @@ class Metric3Dprinted(ThreadProfile):
             t.majorDia = designation.size + offset
             t.pitchDia = designation.size + offset - depth / 4
             t.minorDia = designation.size + offset - depth / 2
+            t.tapDrill = designation.size + offset - depth
             ts.append(t)
         return ts
 

--- a/main.py
+++ b/main.py
@@ -68,18 +68,17 @@ class Metric3Dprinted(ThreadProfile):
             t = Thread()
             t.gender = "external"
             t.clazz = "O.{}".format(offset_decimals)
-            t.majorDia = designation.size - offset - .25
-            t.pitchDia = designation.size - offset - depth / 2 - .7
-            t.minorDia = designation.size - offset - depth - .8
+            t.majorDia = designation.size - offset
+            t.pitchDia = designation.size - offset - depth / 4
+            t.minorDia = designation.size - offset - depth / 2
             ts.append(t)
 
             t = Thread()
             t.gender = "internal"
             t.clazz = "O.{}".format(offset_decimals)
-            t.majorDia = designation.size + offset + .4
-            t.pitchDia = designation.size + offset - depth / 2 - .4
-            t.minorDia = designation.size + offset - depth
-            t.tapDrill = designation.size + offset - depth
+            t.majorDia = designation.size + offset
+            t.pitchDia = designation.size + offset - depth / 4
+            t.minorDia = designation.size + offset - depth / 2
             ts.append(t)
         return ts
 


### PR DESCRIPTION
**This is rather suggestion/showcase than actual code change.**

I find 60° threads quite hard to print vertically, as overhang is just 30° – while FDM starts to have problems for <45° overhangs.

![thread_example](https://github.com/BalzGuenat/CustomThreads/assets/7951939/ba0c7753-d6fb-4f4a-a99c-ba770f6b65dd)

Sure, I thought, I can just change an angle in Python script to make it produce 90° threads. But nope, it doesn't work – seemingly because of hardcoded offsets.

So I tweaked the code a bit to generate 90° threads – they match 90° threads in [dans98/Fusion-360-FDM-threads](https://github.com/dans98/Fusion-360-FDM-threads) – but that generator is in PHP and also requires JSON to be generated by the user.

Let's try to get your generator to support 90° threads – either through my change or modification of hardcoded offsets