### PR TITLE
Threadform

### DIFF
--- a/3DPrintedMetricV3.xml
+++ b/3DPrintedMetricV3.xml
@@ -4,6 +4,7 @@
   <CustomName>3D-printed Metric Threads V3</CustomName>
   <Unit>mm</Unit>
   <Angle>60.0</Angle>
+  <ThreadForm>8</ThreadForm>
   <SortOrder>3</SortOrder>
   <ThreadSize>
     <Size>8</Size>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project defines thread profiles that are aimed at 3D printing so that they 
 The provided `3DPrintedMetricV3.xml` file contains the thread profiles listed below.
 Additional profiles can be easily generated from the included Python script.
 
-**Shape:** 60° trapezoidal  
+**Shape:** 60° whitworth
 **Size (OD):** 8-50mm  
 **Pitch:** 3.5mm, 5mm  
 **Classes:** O.0, O.1, O.2, O.4, O.8
@@ -51,9 +51,16 @@ The script has no parameters and can be executed like so:
 python main.py
 ```
 
-This will create a file named `output.xml` in the working directory which you can then rename and install in Fusion as described above.
+This will create a file named `3DPrintedMetricV3.xml` in the working directory which you can then rename and install in Fusion as described above.
 
 To customize the generated profiles, simply edit the values defined at the top of `main.py`.
+
+To change the profile of the thread change the "THREAD_FORM" variable and reference the below chart.
+
+0 = Trapezoidal
+1 = sharp V shape
+6 = Square
+8 = whitworth
 
 ```python
 NAME = "3D-printed Metric Threads V3"
@@ -62,4 +69,5 @@ ANGLE = 60.0
 SIZES = list(range(8, 51))
 PITCHES = [3.5, 5.0]
 OFFSETS = [.0, .1, .2, .4, .8]
+THREAD_FORM = 8
 ```

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ ANGLE = 60.0
 SIZES = list(range(8, 51))
 PITCHES = [3.5, 5.0]
 OFFSETS = [.0, .1, .2, .4, .8]
+THREAD_FORM = 8
 
 
 def designator(val: float):
@@ -98,6 +99,7 @@ def generate():
     ET.SubElement(root, "CustomName").text = NAME
     ET.SubElement(root, "Unit").text = UNIT
     ET.SubElement(root, "Angle").text = str(ANGLE)
+    ET.SubElement(root, "ThreadForm").text = str(THREAD_FORM)
     ET.SubElement(root, "SortOrder").text = "3"
 
     for size in profile.sizes():


### PR DESCRIPTION
Added a rounded thread profile for better 3d printing, i did that by adding the "threadform" parameter in the XML as well as adding it into the python script.  I also updated the readme to resolve an error where it was incorrectly referencing that an output.xml would be generated when it was not, and then i also added a short description of the threadform parameter.